### PR TITLE
Fixes build problems due to duplicated constants

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,8 +19,7 @@
         <item quantity="few">Läuft mit %1$d Verbindungen.</item>
         <item quantity="other">Läuft mit %1$d Verbindungen.</item>
     </plurals>
-    <string name="notification_not_enabled">Nuntius benötigt Zugriff auf Benachrichtigungen, um aktiviert zu sein</string>
-    <string name="notification_not_enabled">Nuntius möchte Zugriff auf Deine Benachrichtigungen haben</string>
+    <string name="notification_not_enabled">Nuntius benötigt Zugriff auf Deine Benachrichtigungen, um aktiviert zu sein</string>
     <string name="not_paired">Bitte schließen Sie das Gerät an den Computer an</string>
     <string name="version">Programmversion von Nuntius</string>
     <string name="app_blacklist_title">Anwendungen auf Blacklist </string>


### PR DESCRIPTION
Thank you @flyingrub  for you notice. This commit removes
one of those constants and corrects the text only slightly.