### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Nuntius [![Build Status](https://travis-ci.org/holylobster/nuntius-android.svg?branch=master)](https://travis-ci.org/holylobster/nuntius-android)
 ===================================
 
-##Introduction
+## Introduction
 Nuntius delivers notifications from your phone or tablet to your computer over Bluetooth.
 
 Nuntius is an Open Source project from HolyLobster.
@@ -10,12 +10,12 @@ To use Nuntius you will need to install a companion tool on your computer and pa
 
 For more information on the project and the companion tools to install on the computer check https://github.com/holylobster
 
-##The Icon
+## The Icon
 You may have questions on the icon. Nice shot.
 In fact most of the Nuntius development time has been spent on the icon design concept.
 If you have suggestions on how to improve it we are very open... but... we think it is hardly possible to do better than this.
 
-##Packages
+## Packages
 You can download Nuntius from:
 * Google Play Store: https://play.google.com/store/apps/details?id=org.holylobster.nuntius
 * F-Droid (unofficial): https://f-droid.org/repository/browse/?fdid=org.holylobster.nuntius
@@ -25,16 +25,16 @@ You will need to install Nuntius also on your computer.
 At the moment Nuntius is available on some Linux distributions, check here:
 * https://github.com/holylobster/nuntius-linux
 
-##Requirements
+## Requirements
 * Bluetooth: we tested with Bluetooth 2.1 and it worked
 * Android: to intercept notifications we need at least Android 4.3 (API 18)
 * Sympathy: Nuntius is at a very early stage of development. Your participation and understanding is appreciated!
 
-##Note
+## Note
 User is required to enable notification permission from
 * "Settings > Security > Notification access"
 * or "Settings > Sound & notification > Notification access".
 
-##Getting in touch
+## Getting in touch
 We have an IRC channel: #nuntius on the irc.gnome.org server.
 Feel free to join and talk to us! Note that the channel is new and there are not many people (yet!) so be patient and hang around if you do not receive a reply immediately.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
